### PR TITLE
Improve equal contrib markup for the info tab

### DIFF
--- a/lib/xsl/jats-to-html.xsl
+++ b/lib/xsl/jats-to-html.xsl
@@ -436,23 +436,23 @@
     </xsl:template>
 
     <xsl:template match="author-notes/fn[@fn-type='con']">
-        <h4 class="equal-contrib-label">
-            <xsl:apply-templates/>
-        </h4>
-        <xsl:variable name="contriputeid">
-            <xsl:value-of select="@id"/>
-        </xsl:variable>
-        <p>
-            <xsl:for-each select="../../contrib-group/contrib/xref[@rid=$contriputeid]">
-                <xsl:value-of select="../name/given-names"/>
-                <xsl:text> </xsl:text>
-                <xsl:value-of select="../name/surname"/>
-                <xsl:if test="position() != last()">
-                    <xsl:text>, </xsl:text>
-                </xsl:if>
-            </xsl:for-each>
-
-        </p>
+        <section class="equal-contrib">
+            <h4 class="equal-contrib-label">
+                <xsl:apply-templates/>
+            </h4>
+            <xsl:variable name="contriputeid">
+                <xsl:value-of select="@id"/>
+            </xsl:variable>
+            <ul class="equal-contrib-list">
+                <xsl:for-each select="../../contrib-group/contrib/xref[@rid=$contriputeid]">
+                    <li>
+                        <xsl:value-of select="../name/given-names"/>
+                        <xsl:text> </xsl:text>
+                        <xsl:value-of select="../name/surname"/>
+                    </li>
+                </xsl:for-each>
+            </ul>
+        </section>
     </xsl:template>
 
     <xsl:template match="fn-group[@content-type='author-contribution']">

--- a/tests/fixtures/html/00731-v1-vor-section-author-info-equal-contrib.html
+++ b/tests/fixtures/html/00731-v1-vor-section-author-info-equal-contrib.html
@@ -1,2 +1,1 @@
-<h4 class="equal-contrib-label">These authors contributed equally to this work</h4>
-<p>Kentaro Yoshida, Verena J Schuenemann</p>
+<section class="equal-contrib"><h4 class="equal-contrib-label">These authors contributed equally to this work</h4><ul class="equal-contrib-list"><li>Kentaro Yoshida</li><li>Verena J Schuenemann</li></ul></section>


### PR DESCRIPTION
This update addresses two issues in authors' equal contribution section of the article's info tab:
1. it improves modularity by wrapping it in a `<section>` element, ensuring that the heading will only apply to the list of authors within the section.
2. the list of authors is marked up as a `<ul>`

If there are other uses of this markup, the display will need to be checked to determine whether the CSS needs to be updated to cater for the updated html.
