### PR TITLE
Modify output of equal contribution statement in author info section/tab

### DIFF
--- a/lib/xsl/jats-to-html.xsl
+++ b/lib/xsl/jats-to-html.xsl
@@ -486,15 +486,13 @@
 
     <xsl:template match="author-notes/fn[@fn-type='con']">
         <section class="equal-contrib">
-            <h4 class="equal-contrib-label">
-                <xsl:apply-templates/>
-            </h4>
+                <xsl:apply-templates/>:
             <xsl:variable name="contriputeid">
                 <xsl:value-of select="@id"/>
             </xsl:variable>
             <ul class="equal-contrib-list">
                 <xsl:for-each select="../../contrib-group/contrib/xref[@rid=$contriputeid]">
-                    <li>
+                    <li class="equal-contributor">
                         <xsl:value-of select="../name/given-names"/>
                         <xsl:text> </xsl:text>
                         <xsl:value-of select="../name/surname"/>

--- a/tests/fixtures/html/00731-v1-vor-section-author-info-equal-contrib.html
+++ b/tests/fixtures/html/00731-v1-vor-section-author-info-equal-contrib.html
@@ -1,1 +1,1 @@
-<section class="equal-contrib"><h4 class="equal-contrib-label">These authors contributed equally to this work</h4><ul class="equal-contrib-list"><li>Kentaro Yoshida</li><li>Verena J Schuenemann</li></ul></section>
+<section class="equal-contrib">These authors contributed equally to this work: <ul class="equal-contrib-list"><li class="equal-contributor">Kentaro Yoshida</li><li class="equal-contributor">Verena J Schuenemann</li></ul></section>


### PR DESCRIPTION
The equal contribution statement should now form a sentence containing the list of relevant authors, not contain a heading.
